### PR TITLE
Add last sync indicator

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,8 @@
   }
   h1 { text-align: center; }
   #status { font-size: 0.875rem; color: #555; margin-top: 5px; }
+  #syncStatus { font-size: 0.875rem; margin-top: 5px; display: flex; align-items: center; gap: 0.5em; }
+  #syncIndicator { width: 0.75em; height: 0.75em; border-radius: 50%; background: red; display: inline-block; }
   @media (min-width: 600px) {
     body { max-width: 800px; }
     textarea { min-height: 80vh; }
@@ -30,9 +32,13 @@
 <h1>Simple Notepad</h1>
 <textarea id="note" placeholder="Start typing..."></textarea>
 <div id="status"></div>
+<div id="syncStatus"><span id="syncIndicator"></span><span id="syncTime"></span></div>
 <script>
 const textarea = document.getElementById('note');
 const status = document.getElementById('status');
+const syncIndicator = document.getElementById('syncIndicator');
+const syncTime = document.getElementById('syncTime');
+const LAST_SYNC_KEY = 'last-sync-time';
 const STORAGE_KEY = 'notepad-content';
 // URL of the sync server. Change this if you host the server elsewhere.
 const SERVER_URL = 'https://testing-39z9.onrender.com';
@@ -41,8 +47,30 @@ function loadLocal() {
   textarea.value = localStorage.getItem(STORAGE_KEY) || '';
 }
 
+function loadLastSync() {
+  const t = localStorage.getItem(LAST_SYNC_KEY);
+  if (t) {
+    const date = new Date(t);
+    syncTime.textContent = `Last sync: ${date.toLocaleString()}`;
+    syncIndicator.style.background = 'green';
+  }
+}
+
+function setSync(success) {
+  const now = new Date();
+  if (success) {
+    syncIndicator.style.background = 'green';
+    syncTime.textContent = `Last sync: ${now.toLocaleString()}`;
+    localStorage.setItem(LAST_SYNC_KEY, now.toISOString());
+  } else {
+    syncIndicator.style.background = 'red';
+    syncTime.textContent = `Sync failed: ${now.toLocaleString()}`;
+  }
+}
+
 function load() {
   loadLocal();
+  loadLastSync();
   fetch(`${SERVER_URL}/notes`)
     .then(r => r.ok ? r.text() : '')
     .then(text => {
@@ -50,9 +78,11 @@ function load() {
         textarea.value = text;
         localStorage.setItem(STORAGE_KEY, text);
       }
+      setSync(true);
     })
     .catch(() => {
       status.textContent = 'Unable to reach server';
+      setSync(false);
     });
 }
 
@@ -63,9 +93,14 @@ function save() {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ content })
-  }).catch(() => {
-    status.textContent = 'Unable to reach server';
-  });
+  })
+    .then(r => {
+      if (r.ok) setSync(true); else setSync(false);
+    })
+    .catch(() => {
+      status.textContent = 'Unable to reach server';
+      setSync(false);
+    });
   status.textContent = 'Saved';
   setTimeout(() => {
     if (status.textContent === 'Saved') status.textContent = '';

--- a/test/notes.test.js
+++ b/test/notes.test.js
@@ -14,18 +14,21 @@ describe('loadNotes and saveNotes', () => {
     if (fs.existsSync(FILE)) fs.unlinkSync(FILE);
   });
 
-  it('returns empty string when file is missing', () => {
-    expect(loadNotes()).to.equal('');
+  it('returns empty string when file is missing', async () => {
+    const result = await loadNotes();
+    expect(result).to.equal('');
   });
 
-  it('saves and loads content', () => {
-    saveNotes('hello');
-    expect(loadNotes()).to.equal('hello');
+  it('saves and loads content', async () => {
+    await saveNotes('hello');
+    const result = await loadNotes();
+    expect(result).to.equal('hello');
   });
 
-  it('overwrites existing content', () => {
-    saveNotes('first');
-    saveNotes('second');
-    expect(loadNotes()).to.equal('second');
+  it('overwrites existing content', async () => {
+    await saveNotes('first');
+    await saveNotes('second');
+    const result = await loadNotes();
+    expect(result).to.equal('second');
   });
 });


### PR DESCRIPTION
## Summary
- show sync status and time in the notepad UI
- update tests to use async functions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684320f59a7c832ebcbe1c02a863a045