### PR TITLE
Adjust bullet button layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This repository contains a simple notepad web app. Open `index.html` in
 your web browser and begin typing to save notes. Your text is automatically
 stored in the browser so you can return to the page later and continue where you
 left off. The layout now adapts better to small screens so you can comfortably
-use it on phones and tablets. A new **Add Bullet** button lets you prepend a
-• bullet to each selected line.
+use it on phones and tablets. A small bullet button lets you toggle a
+• bullet at the start of each selected line.
 
 ## Hosting with GitHub Pages
 

--- a/index.html
+++ b/index.html
@@ -22,7 +22,20 @@
   #status { font-size: 0.875rem; color: #555; margin-top: 5px; }
   #syncStatus { font-size: 0.875rem; margin-top: 5px; display: flex; align-items: center; gap: 0.5em; }
   #syncIndicator { width: 0.75em; height: 0.75em; border-radius: 50%; background: red; display: inline-block; }
-  #bulletBtn { margin-top: 0.5em; }
+  #bulletBtn {
+    margin: 0.5em 0;
+    display: block;
+    width: 2em;
+    height: 2em;
+    font-size: 1.25rem;
+    line-height: 2em;
+    text-align: center;
+    background: #f0f0f0;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    padding: 0;
+    cursor: pointer;
+  }
   @media (min-width: 600px) {
     body { max-width: 800px; }
     textarea { min-height: 80vh; }
@@ -31,10 +44,10 @@
 </head>
 <body>
 <h1>Simple Notepad</h1>
+<button id="bulletBtn" type="button" aria-label="Add bullet">&bull;</button>
 <textarea id="note" placeholder="Start typing..."></textarea>
-<button id="bulletBtn" type="button">Add Bullet</button>
-<div id="status"></div>
 <div id="syncStatus"><span id="syncIndicator"></span><span id="syncTime"></span></div>
+<div id="status"></div>
 <script>
 const textarea = document.getElementById('note');
 const status = document.getElementById('status');
@@ -70,7 +83,7 @@ function setSync(success) {
   }
 }
 
-function addBullet() {
+function toggleBullet() {
   const start = textarea.selectionStart;
   const end = textarea.selectionEnd;
   const text = textarea.value;
@@ -83,11 +96,13 @@ function addBullet() {
   const after = text.slice(lineEnd);
   const lines = text.slice(lineStart, lineEnd).split('\n');
   const bullet = '• ';
-  const withBullets = lines.map(l => l.startsWith(bullet) ? l : bullet + l).join('\n');
+  const toggled = lines
+    .map(l => l.startsWith(bullet) ? l.slice(bullet.length) : bullet + l)
+    .join('\n');
 
-  textarea.value = before + withBullets + after;
+  textarea.value = before + toggled + after;
   textarea.selectionStart = lineStart;
-  textarea.selectionEnd = lineStart + withBullets.length;
+  textarea.selectionEnd = lineStart + toggled.length;
   save();
 }
 
@@ -131,7 +146,7 @@ function save() {
 }
 
 textarea.addEventListener('input', save);
-document.getElementById('bulletBtn').addEventListener('click', addBullet);
+document.getElementById('bulletBtn').addEventListener('click', toggleBullet);
 
 load();
 </script>


### PR DESCRIPTION
## Summary
- move Add Bullet button below the page title
- make the bullet button a compact square bullet
- show sync timestamp before the save status
- left-align bullet button and allow toggling bullets

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68437bfcb214832ebe3ebbfda4db6b36