### PR TITLE
Add Google Gemini integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ npm install
 npm start
 ```
 
+To enable the optional Gemini integration, provide your Google API key when
+starting the server:
+
+```bash
+GEMINI_API_KEY=your_key npm start
+```
+
 This runs the `start` script defined in `package.json`.
 
 ## Running Tests

--- a/index.html
+++ b/index.html
@@ -53,13 +53,16 @@
   <button id="indentBtn" type="button" aria-label="Indent">⇥</button>
   <button id="undoBtn" type="button" aria-label="Undo">↺</button>
   <button id="redoBtn" type="button" aria-label="Redo">↻</button>
+  <button id="geminiBtn" type="button" aria-label="Gemini">Gemini</button>
 </div>
 <textarea id="note" placeholder="Start typing..."></textarea>
 <div id="syncStatus"><span id="syncIndicator"></span><span id="syncTime"></span></div>
 <div id="status"></div>
+<span id="geminiResult"></span>
 <script>
 const textarea = document.getElementById('note');
 const status = document.getElementById('status');
+const geminiResult = document.getElementById('geminiResult');
 const syncIndicator = document.getElementById('syncIndicator');
 const syncTime = document.getElementById('syncTime');
 const LAST_SYNC_KEY = 'last-sync-time';
@@ -251,12 +254,30 @@ function save() {
   }, 1000);
 }
 
+function runGemini() {
+  const prompt = textarea.value;
+  geminiResult.textContent = 'Thinking...';
+  fetch(`${SERVER_URL}/gemini`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ prompt })
+  })
+    .then(r => r.ok ? r.json() : Promise.reject())
+    .then(data => {
+      geminiResult.textContent = data.text || '';
+    })
+    .catch(() => {
+      geminiResult.textContent = 'Error contacting Gemini';
+    });
+}
+
 textarea.addEventListener('input', handleInput);
 document.getElementById('bulletBtn').addEventListener('click', toggleBullet);
 document.getElementById('indentBtn').addEventListener('click', indentSelection);
 document.getElementById('outdentBtn').addEventListener('click', outdentSelection);
 document.getElementById('undoBtn').addEventListener('click', undo);
 document.getElementById('redoBtn').addEventListener('click', redo);
+document.getElementById('geminiBtn').addEventListener('click', runGemini);
 
 document.addEventListener('keydown', e => {
   if ((e.ctrlKey || e.metaKey) && !e.shiftKey && e.key === 'z') {

--- a/server.js
+++ b/server.js
@@ -7,6 +7,9 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 const FILE = path.join(__dirname, 'notes.txt');
 
+const GEMINI_URL =
+  'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent';
+
 app.use(cors());
 app.use(express.json());
 
@@ -41,6 +44,35 @@ app.post('/notes', async (req, res) => {
     }
   } else {
     res.sendStatus(400);
+  }
+});
+
+app.post('/gemini', async (req, res) => {
+  const prompt = req.body.prompt;
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (typeof prompt !== 'string') {
+    return res.sendStatus(400);
+  }
+  if (!apiKey) {
+    return res.status(500).send('GEMINI_API_KEY missing');
+  }
+  try {
+    const response = await fetch(`${GEMINI_URL}?key=${apiKey}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contents: [{ parts: [{ text: prompt }] }]
+      })
+    });
+    if (!response.ok) {
+      return res.sendStatus(500);
+    }
+    const data = await response.json();
+    const text =
+      data.candidates?.[0]?.content?.parts?.[0]?.text || '';
+    res.json({ text });
+  } catch (err) {
+    res.sendStatus(500);
   }
 });
 


### PR DESCRIPTION
## Summary
- add `/gemini` endpoint in server to forward prompts to Google Gemini API
- show a "Gemini" button in the UI and display generated responses
- document `GEMINI_API_KEY` env var in README

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684397f68880832eac965782c04c9286