### PR TITLE
Improve Gemini error handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,9 +262,13 @@ function runGemini() {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ prompt })
   })
-    .then(r => r.ok ? r.json() : Promise.reject())
+    .then(r => r.json())
     .then(data => {
-      geminiResult.textContent = data.text || '';
+      if (data.error) {
+        geminiResult.textContent = data.error;
+      } else {
+        geminiResult.textContent = data.text || '';
+      }
     })
     .catch(() => {
       geminiResult.textContent = 'Error contacting Gemini';

--- a/server.js
+++ b/server.js
@@ -65,14 +65,17 @@ app.post('/gemini', async (req, res) => {
       })
     });
     if (!response.ok) {
-      return res.sendStatus(500);
+      const errText = await response.text();
+      console.error('Gemini API error:', errText);
+      return res.status(500).json({ error: 'Gemini API error' });
     }
     const data = await response.json();
     const text =
       data.candidates?.[0]?.content?.parts?.[0]?.text || '';
     res.json({ text });
   } catch (err) {
-    res.sendStatus(500);
+    console.error('Gemini handler error:', err);
+    res.status(500).json({ error: err.message || 'Gemini request failed' });
   }
 });
 


### PR DESCRIPTION
## Summary
- log Gemini API and handler errors
- return `{ error }` JSON when Gemini fails
- surface Gemini errors in the UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843a090b28c832e9db1aa74c2b3dfec