### PR TITLE
Update Gemini model endpoint

### DIFF
--- a/server.js
+++ b/server.js
@@ -7,8 +7,10 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 const FILE = path.join(__dirname, 'notes.txt');
 
+// Use the newer Gemini 1.5 Pro model for API requests.
+// See https://ai.google.dev/docs/start for available model names.
 const GEMINI_URL =
-  'https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent';
+  'https://generativelanguage.googleapis.com/v1/models/gemini-1.5-pro:generateContent';
 
 app.use(cors());
 app.use(express.json());


### PR DESCRIPTION
## Summary
- update the Gemini API URL to use the `gemini-1.5-pro` model

## Testing
- `npm install --silent`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6844149075d8832eb4836771514ba270