### PR TITLE
Switch to Gemini 2.5 model

### DIFF
--- a/server.js
+++ b/server.js
@@ -7,10 +7,10 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 const FILE = path.join(__dirname, 'notes.txt');
 
-// Use the Gemini 1.5 Pro 002 model for API requests.
+// Use the Gemini 2.5 Flash Preview 05-20 model for API requests.
 // See https://ai.google.dev/docs/start for available model names.
 const GEMINI_URL =
-  'https://generativelanguage.googleapis.com/v1/models/gemini-1.5-pro-002:generateContent';
+  'https://generativelanguage.googleapis.com/v1/models/gemini-2.5-flash-preview-05-20:generateContent';
 
 app.use(cors());
 app.use(express.json());


### PR DESCRIPTION
## Summary
- switch to the gemini-2.5-flash-preview-05-20 model for Gemini API calls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6844204ede90832eb3499f4d77cc4bee