### PR TITLE
Revert to gemini-2.0-flash model

### DIFF
--- a/server.js
+++ b/server.js
@@ -7,10 +7,10 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 const FILE = path.join(__dirname, 'notes.txt');
 
-// Use the Gemini 2.5 Flash Preview model for API requests.
+// Use the Gemini 2.0 Flash model for API requests.
 // See https://ai.google.dev/docs/start for available model names.
 const GEMINI_URL =
-  'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview:generateContent';
+  'https://generativelanguage.googleapis.com/v1/models/gemini-2.0-flash:generateContent';
 
 app.use(cors());
 app.use(express.json());


### PR DESCRIPTION
## Summary
- roll back server.js to use gemini-2.0-flash instead of the preview 2.5 model

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68462910e4e8832eb130753fe4b0afce