### PR TITLE
Add manual sync button

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ your web browser and begin typing to save notes. Your text is automatically
 stored in the browser so you can return to the page later and continue where you
 left off. The layout now adapts better to small screens so you can comfortably
 use it on phones and tablets. A small bullet button lets you toggle a
-• bullet at the start of each selected line.
+• bullet at the start of each selected line. A refresh button in the toolbar
+pulls the latest notes from the server when you want to sync manually.
 
 ## Hosting with GitHub Pages
 
@@ -41,6 +42,9 @@ GEMINI_API_KEY=your_key npm start
 ```
 
 This runs the `start` script defined in `package.json`.
+
+When switching devices, click the refresh button in the toolbar to pull the
+latest saved notes from the server.
 
 ## Enabling the Gemini API
 

--- a/index.html
+++ b/index.html
@@ -62,6 +62,7 @@
   <button id="redoBtn" type="button" aria-label="Redo">↻</button>
   <button id="geminiBtn" type="button" aria-label="Gemini">AI</button>
   <button id="gaBtn" type="button" aria-label="Copy to Google AI">GA</button>
+  <button id="syncBtn" type="button" aria-label="Sync from server">⟳</button>
   <span id="geminiResult"></span>
 </div>
 <textarea id="note" placeholder="Start typing..."></textarea>
@@ -324,6 +325,7 @@ document.getElementById('undoBtn').addEventListener('click', undo);
 document.getElementById('redoBtn').addEventListener('click', redo);
 document.getElementById('geminiBtn').addEventListener('click', runGemini);
 document.getElementById('gaBtn').addEventListener('click', copyToGoogleAI);
+document.getElementById('syncBtn').addEventListener('click', fetchNotes);
 
 textarea.addEventListener('keydown', e => {
   if (e.key === 'Tab') {


### PR DESCRIPTION
## Summary
- add a refresh button that calls `fetchNotes()`
- document manual sync feature in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685083923410832ea6f92e34680fb055