### PR TITLE
Add hyperlink support for Gemini output

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,6 +82,13 @@ const redoStack = [];
 let lastValue = '';
 const MAX_STACK = 50;
 
+function linkify(text) {
+  const escapeMap = { '&': '&amp;', '<': '&lt;', '>': '&gt;' };
+  const escaped = text.replace(/[&<>]/g, c => escapeMap[c] || c);
+  return escaped.replace(/(https?:\/\/\S+)/g,
+    url => `<a href="${url}" target="_blank" rel="noopener">${url}</a>`);
+}
+
 function loadLocal() {
   textarea.value = localStorage.getItem(STORAGE_KEY) || '';
   lastValue = textarea.value;
@@ -292,7 +299,7 @@ function runGemini() {
       if (data.error) {
         geminiResult.textContent = data.error;
       } else {
-        geminiResult.textContent = data.text || '';
+        geminiResult.innerHTML = linkify(data.text || '');
       }
     })
     .catch(() => {


### PR DESCRIPTION
## Summary
- convert URLs in the Gemini result into clickable links

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850bbfaa748832ead8d180f23f71db7