### PR TITLE
Add PIN support for notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,10 @@ requires **Node.js 18 or newer**:
 ```bash
 npm install
 npm start
+```
+
+## Authentication
+
+Set the `NOTES_PIN` environment variable when starting the server to
+require a matching `pin` value on `/notes` requests. The notepad UI will
+prompt for this pin and include it with requests.

--- a/index.html
+++ b/index.html
@@ -81,10 +81,20 @@ const syncTime = document.getElementById('syncTime');
 const LAST_SYNC_KEY = 'last-sync-time';
 const STORAGE_KEY = 'notepad-content';
 const SERVER_URL = 'https://testing-39z9.onrender.com';
+const PIN_KEY = 'notes-pin';
 const undoStack = [];
 const redoStack = [];
 let lastValue = '';
 const MAX_STACK = 50;
+
+function getPin() {
+  let pin = localStorage.getItem(PIN_KEY);
+  if (!pin) {
+    pin = prompt('Enter PIN');
+    if (pin) localStorage.setItem(PIN_KEY, pin);
+  }
+  return pin || '';
+}
 
 function linkify(text) {
   const escapeMap = { '&': '&amp;', '<': '&lt;', '>': '&gt;' };
@@ -245,8 +255,9 @@ function handleInput() {
   save();
 }
 
-  function fetchNotes() {
-  const url = `${SERVER_URL}/notes?t=${Date.now()}`;
+function fetchNotes() {
+  const pin = getPin();
+  const url = `${SERVER_URL}/notes?pin=${encodeURIComponent(pin)}&t=${Date.now()}`;
   fetch(url, { cache: 'no-store' })
     .then(r => r.ok ? r.text() : '')
     .then(text => {
@@ -273,7 +284,8 @@ function load() {
 function save() {
   const content = textarea.value;
   localStorage.setItem(STORAGE_KEY, content);
-  fetch(`${SERVER_URL}/notes`, {
+  const pin = getPin();
+  fetch(`${SERVER_URL}/notes?pin=${encodeURIComponent(pin)}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ content })

--- a/server.js
+++ b/server.js
@@ -6,6 +6,7 @@ const path = require('path');
 const app = express();
 const PORT = process.env.PORT || 3000;
 const FILE = path.join(__dirname, 'notes.txt');
+const NOTES_PIN = process.env.NOTES_PIN || '';
 
 // Use the Gemini 2.0 Flash model for API requests.
 // See https://ai.google.dev/docs/start for available model names.
@@ -28,6 +29,8 @@ async function saveNotes(content) {
 }
 
 app.get('/notes', async (req, res) => {
+  const pin = req.query.pin || req.get('pin');
+  if (NOTES_PIN && pin !== NOTES_PIN) return res.sendStatus(403);
   try {
     const content = await loadNotes();
     res
@@ -40,6 +43,8 @@ app.get('/notes', async (req, res) => {
 });
 
 app.post('/notes', async (req, res) => {
+  const pin = req.query.pin || req.get('pin');
+  if (NOTES_PIN && pin !== NOTES_PIN) return res.sendStatus(403);
   if (typeof req.body.content === 'string') {
     try {
       await saveNotes(req.body.content);


### PR DESCRIPTION
## Summary
- secure `/notes` endpoints with new `NOTES_PIN` env variable
- support PIN in client fetch logic
- prompt for PIN in UI and document authentication

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852f43cf9b8832e8e5d77421ab71cbb