### PR TITLE
Append date to Gemini prompt

### DIFF
--- a/index.html
+++ b/index.html
@@ -358,7 +358,8 @@
     }
 
     function runGemini() {
-      const prompt = textarea.value;
+      const now = new Date().toLocaleString();
+      const prompt = textarea.value + "\nCurrent date and time: " + now;
       geminiResult.textContent = 'Thinking...';
       fetch(`${SERVER_URL}/gemini`, {
         method: 'POST',

--- a/test/gemini.test.js
+++ b/test/gemini.test.js
@@ -1,0 +1,35 @@
+const { expect } = require('chai');
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('runGemini', () => {
+  it('includes current date and time in the prompt', async () => {
+    const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+    let captured;
+    const dom = new JSDOM(html, {
+      url: 'http://localhost',
+      runScripts: 'dangerously',
+      resources: 'usable',
+      beforeParse(window) {
+        window.fetch = (_url, opts = {}) => {
+          if (opts.body) {
+            captured = JSON.parse(opts.body).prompt;
+          }
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ text: '' }),
+            text: () => Promise.resolve('')
+          });
+        };
+        window.prompt = () => '0043';
+      }
+    });
+    dom.window.document.getElementById('note').value = 'hello';
+    dom.window.runGemini();
+    await new Promise(r => setTimeout(r, 0));
+    expect(captured).to.include('hello');
+    expect(captured).to.match(/Current date and time:/);
+    dom.window.close();
+  });
+});


### PR DESCRIPTION
## Summary
- send the current date and time when calling the Gemini API
- add a unit test for the new Gemini prompt behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685325196fe8832e8ff86fbaa424fac0