### PR TITLE
Fix mobile toolbar layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,13 @@
       flex: 1;
       overflow-wrap: anywhere;
     }
+    @media (max-width: 599px) {
+      #toolbar { flex-wrap: wrap; }
+      #geminiResult {
+        flex-basis: 100%;
+        margin-left: 0;
+      }
+    }
     @media (min-width: 600px) {
       body { max-width: 800px; }
       textarea { min-height: 80vh; }


### PR DESCRIPTION
## Summary
- allow wrapping gemini output under toolbar on narrow screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68536190f460832e89c01ba94964121b