### PR TITLE
Remove heading, adjust Gemini font

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Simple Notepad</title>
+  <title>Notepad</title>
   <link rel="icon" href="data:,">
   <style>
     body {
@@ -44,7 +44,7 @@
       font-weight: bold;
     }
     #geminiResult {
-      font-size: 0.875rem;
+      font-size: clamp(1rem, 2.5vw, 1.125rem);
       line-height: 2em;
       margin-left: 0.5em;
       flex: 1;
@@ -64,7 +64,6 @@
   </style>
 </head>
 <body>
-  <h1>Simple Notepad</h1>
   <div id="toolbar">
     <button id="bulletBtn" type="button" aria-label="Add bullet">&bull;</button>
     <button id="outdentBtn" type="button" aria-label="Remove indent">⇤</button>


### PR DESCRIPTION
## Summary
- remove Simple Notepad heading and title wording
- show Gemini responses in the same font size as the note area

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6853653033a8832eb36267e5d19926bb