### PR TITLE
Implement restoreFromCloud error handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -444,10 +444,15 @@
       const pin = getPin();
       if (pin === null) return;
       fetch(`${SERVER_URL}/restore?pin=${encodeURIComponent(pin)}`)
-        .then(r => r.text())
-        .then(text => {
-          textarea.value = text;
-          save();
+        .then(r => {
+          if (r.ok) {
+            return r.text().then(text => {
+              textarea.value = text;
+              save();
+              status.textContent = 'Restored from cloud';
+            });
+          }
+          status.textContent = 'Restore failed';
         })
         .catch(() => {
           status.textContent = 'Restore failed';

--- a/test/restore.test.js
+++ b/test/restore.test.js
@@ -1,0 +1,29 @@
+const { expect } = require('chai');
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('restoreFromCloud failure', () => {
+  it('does not change textarea when response not ok', async () => {
+    const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+    const dom = new JSDOM(html, {
+      url: 'http://localhost',
+      runScripts: 'dangerously',
+      resources: 'usable',
+      beforeParse(window) {
+        window.fetch = () => Promise.resolve({
+          ok: false,
+          status: 500,
+          text: () => Promise.resolve('error')
+        });
+        window.prompt = () => '0043';
+      }
+    });
+    const textarea = dom.window.document.getElementById('note');
+    textarea.value = 'local text';
+    dom.window.restoreFromCloud();
+    await new Promise(r => setTimeout(r, 0));
+    expect(textarea.value).to.equal('local text');
+    dom.window.close();
+  });
+});


### PR DESCRIPTION
## Summary
- check the response from `/restore` before updating the note
- add regression test for restore failure cases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854636218d0832eb2c30bf62be38727