### PR TITLE
Remove manual sync button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Testing Repo
 
-This repository contains a simple notepad web app. Open `index.html` in your web browser and begin typing to save notes. Your text is automatically stored in the browser so you can return to the page later and continue where you left off. The layout now adapts better to small screens so you can comfortably use it on phones and tablets. A small bullet button lets you toggle a • bullet at the start of each selected line. A refresh button (⟳) in the toolbar pulls the latest notes from the server when you want to sync manually.
+This repository contains a simple notepad web app. Open `index.html` in your web browser and begin typing to save notes. Your text is automatically stored in the browser so you can return to the page later and continue where you left off. The layout now adapts better to small screens so you can comfortably use it on phones and tablets. A small bullet button lets you toggle a • bullet at the start of each selected line.
 
 ## Hosting with GitHub Pages
 
@@ -22,7 +22,7 @@ npm install
 npm start
 ```
 
-This command launches the sync server on port 3000. While it runs, open `index.html` in your browser to use the notepad. Your notes automatically save and sync a few seconds after you stop typing. Click the ⟳ button anytime to pull the latest version from the server.
+This command launches the sync server on port 3000. While it runs, open `index.html` in your browser to use the notepad. Your notes automatically save and sync a few seconds after you stop typing.
 
 To run the automated tests:
 

--- a/index.html
+++ b/index.html
@@ -79,7 +79,6 @@
     <button id="geminiBtn" type="button" aria-label="Gemini">AI</button>
     <button id="gaBtn" type="button" aria-label="Copy to Google AI">G</button>
     <button id="o4Btn" type="button" aria-label="Copy to ChatGPT o4">o4</button>
-    <button id="syncBtn" type="button" aria-label="Sync from server">⟳</button>
     <button id="backupBtn" type="button" aria-label="Save to Cloud">⬆️</button>
     <button id="restoreBtn" type="button" aria-label="Restore from Cloud">⬇️</button>
     <span id="geminiResult"></span>
@@ -468,7 +467,6 @@
     document.getElementById('geminiBtn').addEventListener('click', runGemini);
     document.getElementById('gaBtn').addEventListener('click', copyToGoogleAI);
     document.getElementById('o4Btn').addEventListener('click', copyToO4);
-    document.getElementById('syncBtn').addEventListener('click', fetchNotes);
     document.getElementById('backupBtn').addEventListener('click', backupToCloud);
     document.getElementById('restoreBtn').addEventListener('click', restoreFromCloud);
 


### PR DESCRIPTION
## Summary
- remove the manual refresh button from the toolbar
- update README to reflect removal of the manual sync option

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854718beab0832eab09143e9c8a931e