### PR TITLE
Change cloud backup icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,5 +52,5 @@ When these variables are defined the server provides two extra routes:
 - `POST /backup` – Upload the contents of `notes.txt` to the table.
 - `GET /restore` – Retrieve the stored text and overwrite `notes.txt`.
 
-The page adds **Save to Cloud** (⬆️) and **Restore from Cloud** (⬇️)
+The page adds **Save to Cloud** (💾) and **Restore from Cloud** (⬇️)
 buttons that call these routes.

--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
     <button id="geminiBtn" type="button" aria-label="Gemini">AI</button>
     <button id="gaBtn" type="button" aria-label="Copy to Google AI">G</button>
     <button id="o4Btn" type="button" aria-label="Copy to ChatGPT o4">o4</button>
-    <button id="backupBtn" type="button" aria-label="Save to Cloud">⬆️</button>
+    <button id="backupBtn" type="button" aria-label="Save to Cloud">💾</button>
     <button id="restoreBtn" type="button" aria-label="Restore from Cloud">⬇️</button>
     <span id="geminiResult"></span>
   </div>


### PR DESCRIPTION
## Summary
- tweak toolbar to use a floppy disk icon for Save to Cloud
- update docs to show new icon

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68599713285c832eb280e7d76d00fd17