### PR TITLE
Add wrap toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,6 +88,7 @@
     <button id="indentBtn" type="button" aria-label="Indent">⇥</button>
     <button id="undoBtn" type="button" aria-label="Undo">↺</button>
     <button id="redoBtn" type="button" aria-label="Redo">↻</button>
+    <button id="wrapBtn" type="button" aria-label="Toggle wrap">↩</button>
     <button id="geminiBtn" type="button" aria-label="Gemini">AI</button>
     <button id="gaBtn" type="button" aria-label="Copy to Google AI">G</button>
     <button id="o4Btn" type="button" aria-label="Copy to ChatGPT o4">o4</button>
@@ -103,7 +104,9 @@
     const geminiResult = document.getElementById('geminiResult');
     const dirtyIndicator = document.getElementById('dirtyIndicator');
     const cloudIndicator = document.getElementById('cloudIndicator');
+    const wrapBtn = document.getElementById('wrapBtn');
     const STORAGE_KEY = 'notepad-content';
+    const WRAP_KEY = 'notepad-wrap';
     const SERVER_URL = 'https://testing-39z9.onrender.com';
     const PIN_KEY = 'notes-pin';
     const DEFAULT_PIN = '0043';
@@ -113,6 +116,7 @@
     const MAX_STACK = 50;
     let dirty = false;
     let cloudDirty = false;
+    let wrapped = false;
     let statusTimer;
 
     function getPin() {
@@ -179,6 +183,17 @@
       textarea.value = value;
       lastValue = value;
       save();
+    }
+
+    function setWrapping(on) {
+      wrapped = on;
+      textarea.style.whiteSpace = on ? 'pre-wrap' : 'pre';
+      textarea.setAttribute('wrap', on ? 'soft' : 'off');
+      localStorage.setItem(WRAP_KEY, on ? '1' : '0');
+    }
+
+    function toggleWrap() {
+      setWrapping(!wrapped);
     }
 
     function toggleBullet() {
@@ -333,6 +348,7 @@
       fetchNotes();
       updateDirtyIndicator();
       updateCloudIndicator();
+      setWrapping(localStorage.getItem(WRAP_KEY) === '1');
     }
 
     function save() {
@@ -482,6 +498,7 @@
     document.getElementById('outdentBtn').addEventListener('click', outdentSelection);
     document.getElementById('undoBtn').addEventListener('click', undo);
     document.getElementById('redoBtn').addEventListener('click', redo);
+    document.getElementById('wrapBtn').addEventListener('click', toggleWrap);
     document.getElementById('geminiBtn').addEventListener('click', runGemini);
     document.getElementById('gaBtn').addEventListener('click', copyToGoogleAI);
     document.getElementById('o4Btn').addEventListener('click', copyToO4);

--- a/test/wrap.test.js
+++ b/test/wrap.test.js
@@ -1,0 +1,28 @@
+const { expect } = require('chai');
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('toggleWrap', () => {
+  it('toggles the wrap attribute and saves preference', () => {
+    const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+    const dom = new JSDOM(html, {
+      url: 'http://localhost',
+      runScripts: 'dangerously',
+      resources: 'usable',
+      beforeParse(window) {
+        window.fetch = () => Promise.resolve({ ok: true, text: () => Promise.resolve('') });
+        window.prompt = () => '0043';
+      }
+    });
+    const textarea = dom.window.document.getElementById('note');
+    expect(textarea.getAttribute('wrap')).to.equal('off');
+    dom.window.toggleWrap();
+    expect(textarea.getAttribute('wrap')).to.equal('soft');
+    expect(dom.window.localStorage.getItem('notepad-wrap')).to.equal('1');
+    dom.window.toggleWrap();
+    expect(textarea.getAttribute('wrap')).to.equal('off');
+    expect(dom.window.localStorage.getItem('notepad-wrap')).to.equal('0');
+    dom.window.close();
+  });
+});


### PR DESCRIPTION
## Summary
- add a toolbar button for toggling line wrapping
- store the wrapping preference in localStorage
- test the new toggleWrap function

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859972986fc832e80d6e28319445461