### PR TITLE
Add cut line button

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,6 +88,7 @@
     <button id="indentBtn" type="button" aria-label="Indent">⇥</button>
     <button id="undoBtn" type="button" aria-label="Undo">↺</button>
     <button id="redoBtn" type="button" aria-label="Redo">↻</button>
+    <button id="cutLineBtn" type="button" aria-label="Cut line">✂️</button>
     <button id="wrapBtn" type="button" aria-label="Toggle wrap">↩</button>
     <button id="geminiBtn" type="button" aria-label="Gemini">AI</button>
     <button id="gaBtn" type="button" aria-label="Copy to Google AI">G</button>
@@ -285,6 +286,37 @@
       textarea.focus();
       textarea.selectionStart = lineStart;
       textarea.selectionEnd = lineStart + outdented.length;
+      textarea.scrollTop = scrollPos;
+      lastValue = textarea.value;
+      save();
+    }
+
+    function cutLine() {
+      pushUndo(textarea.value);
+      const pos = textarea.selectionStart;
+      const scrollPos = textarea.scrollTop;
+      const text = textarea.value;
+
+      let lineStart = text.lastIndexOf('\n', pos - 1) + 1;
+      let lineEnd = text.indexOf('\n', pos);
+      let sliceEnd = lineEnd === -1 ? text.length : lineEnd + 1;
+
+      const line = text.slice(lineStart, sliceEnd);
+
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(line);
+      } else {
+        const temp = document.createElement('textarea');
+        temp.value = line;
+        document.body.appendChild(temp);
+        temp.select();
+        try { document.execCommand('copy'); } catch (err) {}
+        document.body.removeChild(temp);
+      }
+
+      textarea.value = text.slice(0, lineStart) + text.slice(sliceEnd);
+      textarea.focus();
+      textarea.selectionStart = textarea.selectionEnd = lineStart;
       textarea.scrollTop = scrollPos;
       lastValue = textarea.value;
       save();
@@ -498,6 +530,7 @@
     document.getElementById('outdentBtn').addEventListener('click', outdentSelection);
     document.getElementById('undoBtn').addEventListener('click', undo);
     document.getElementById('redoBtn').addEventListener('click', redo);
+    document.getElementById('cutLineBtn').addEventListener('click', cutLine);
     document.getElementById('wrapBtn').addEventListener('click', toggleWrap);
     document.getElementById('geminiBtn').addEventListener('click', runGemini);
     document.getElementById('gaBtn').addEventListener('click', copyToGoogleAI);

--- a/test/cutLine.test.js
+++ b/test/cutLine.test.js
@@ -1,0 +1,30 @@
+const { expect } = require('chai');
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('cutLine', () => {
+  it('cuts the current line and copies it to clipboard', () => {
+    const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+    let copied;
+    const dom = new JSDOM(html, {
+      url: 'http://localhost',
+      runScripts: 'dangerously',
+      resources: 'usable',
+      beforeParse(window) {
+        window.fetch = () => Promise.resolve({ ok: true, text: () => Promise.resolve('') });
+        window.prompt = () => '0043';
+        window.navigator.clipboard = {
+          writeText: text => { copied = text; return Promise.resolve(); }
+        };
+      }
+    });
+    const textarea = dom.window.document.getElementById('note');
+    textarea.value = 'one\ntwo\nthree';
+    textarea.selectionStart = textarea.selectionEnd = 5; // inside second line
+    dom.window.cutLine();
+    expect(textarea.value).to.equal('one\nthree');
+    expect(copied).to.equal('two\n');
+    dom.window.close();
+  });
+});


### PR DESCRIPTION
## Summary
- add a new ✂️ button to toolbar
- implement `cutLine` function to cut the current line to clipboard
- listen for button click
- test new cut line behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a9ab2b298832ea11e066f901c8c08