### PR TITLE
Add Supabase setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,12 @@ To run the automated tests:
 npm test
 ```
 
+## Supabase setup
+
+1. In Supabase create a new table named `notes` with columns:
+   - `id` UUID (primary key)
+   - `content` text
+2. Enable Row Level Security (RLS) on the table.
+3. Add an "Allow anon insert" policy so anyone can save notes.
+4. Update `SUPABASE_URL` and `SUPABASE_KEY` in `index.html` with
+your project's anon key values.


### PR DESCRIPTION
## Summary
- document how to create the `notes` table in Supabase
- show how to enable RLS and allow anon insert
- explain that the anon key must be placed in `index.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687581e4d9f8832e8a15d5d645e0b88f