### PR TITLE
Handle Ctrl+S save shortcut

### DIFF
--- a/index.html
+++ b/index.html
@@ -489,6 +489,9 @@
       } else if ((e.ctrlKey || e.metaKey) && (e.key === 'y' || (e.shiftKey && e.key === 'z'))) {
         e.preventDefault();
         redo();
+      } else if ((e.ctrlKey || e.metaKey) && !e.shiftKey && e.key.toLowerCase() === 's') {
+        e.preventDefault();
+        saveRemote();
       }
     });
 

--- a/test/saveShortcut.test.js
+++ b/test/saveShortcut.test.js
@@ -1,0 +1,32 @@
+const { expect } = require('chai');
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('Ctrl+S shortcut', () => {
+  it('saves remotely and prevents default', async () => {
+    const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+    let saved = false;
+    const dom = new JSDOM(html, {
+      url: 'http://localhost',
+      runScripts: 'dangerously',
+      resources: 'usable',
+      beforeParse(window) {
+        window.fetch = () => {
+          saved = true;
+          return Promise.resolve({ ok: true, text: () => Promise.resolve('') });
+        };
+      }
+    });
+    const event = new dom.window.KeyboardEvent('keydown', {
+      key: 's',
+      ctrlKey: true,
+      cancelable: true
+    });
+    dom.window.document.dispatchEvent(event);
+    await new Promise(r => setTimeout(r, 0));
+    expect(event.defaultPrevented).to.be.true;
+    expect(saved).to.be.true;
+    dom.window.close();
+  });
+});


### PR DESCRIPTION
## Summary
- intercept `Ctrl+S`/`Cmd+S` to trigger `saveRemote` instead of the browser "Save Page" dialog
- add regression test for the new keyboard shortcut

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6875aaea0de8832eb8d901f8561a74f8