### PR TITLE
Update grounding field name for Gemini search

### DIFF
--- a/index.html
+++ b/index.html
@@ -458,7 +458,10 @@
             geminiResult.innerHTML = linkify(data.text || "");
             if (Array.isArray(data.citations)) {
               geminiCitations.innerHTML = data.citations
-                .map(c => `<li><a href="${c.url}" target="_blank">${c.url}</a></li>`)
+                .map(c => {
+                  const url = c.url || c;
+                  return `<li><a href="${url}" target="_blank">${url}</a></li>`;
+                })
                 .join("");
             }
           }

--- a/server.js
+++ b/server.js
@@ -41,7 +41,7 @@ app.post('/gemini', async (req, res) => {
     const part = candidate?.content?.parts?.[0];
     const text = part?.text || '';
     const citations =
-      part?.groundingMetadata?.webSearchQueries || [];
+      part?.groundingMetadata?.web_search_queries || [];
     res.json({ text, citations });
   } catch (err) {
     console.error('Gemini handler error:', err);


### PR DESCRIPTION
## Summary
- read Gemini protobuf definitions
- adjust server to read `web_search_queries`
- handle URL strings from the API response

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876fd32f258832e8bf7dadcb12d13f6